### PR TITLE
Prevent excess <p> tags in postlist

### DIFF
--- a/_includes/postslist.njk
+++ b/_includes/postslist.njk
@@ -1,8 +1,11 @@
-{%- css %}.postlist { counter-reset: start-from {{ (postslistCounter or postslist.length) + 1 }} }{% endcss %}
+{%- css -%}
+.postlist { counter-reset: start-from {{ (postslistCounter or postslist.length) + 1 }} }
+.postlist-item { margin-block: 2rem; }
+{%- endcss -%}
 <ul reversed class="postlist">
-{% for post in postslist | reverse %}
+{%- for post in postslist | reverse -%}
 	<li class="postlist-item{% if post.url == url %} postlist-item-active{% endif %}">
-		<a href="{{ post.url }}" class="postlist-link">{% if post.data.title %}{{ post.data.title }}{% else %}<code>{{ post.url }}</code>{% endif %}</a>
+		<a href="{{ post.url }}" class="postlist-link">{%- if post.data.title -%}{{ post.data.title }}{%- else -%}<code>{{ post.url }}</code>{%- endif -%}</a>
 	</li>
-{% endfor %}
+{%- endfor -%}
 </ul>


### PR DESCRIPTION
This bug was the result of the order 11ty processes templates.

The empty lines created by nunjucks statements like `{% for post in ... %}` are interpreted as `<p>` when 11ty parses the template as markdown. This created extra `<p>` elements between `<li>` elements. Direct children of `<ul>` should be `<li>` only.

We can prevent the output of newlines in nunjucks statements using `{%-   -%}` in place of `{%   %}` (note the hyphens).