### PR TITLE
include link to rss feed in nav

### DIFF
--- a/_includes/navigation.njk
+++ b/_includes/navigation.njk
@@ -1,7 +1,9 @@
-{%- from "macros.njk" import renderNavListItem %}
-{%- set navPages = collections.all | eleventyNavigation %}
+{%- from "macros.njk" import renderNavListItem -%}
+{%- set navPages = collections.all | eleventyNavigation -%}
+{%- set rssFeedEntry = { title: "RSS Feed", url: "/feed.xml" } -%}
 <nav>
   <ul class="nav">
-{%- for entry in navPages %}{{ renderNavListItem(entry) }}{%- endfor -%}
+	{{ renderNavListItem(rssFeedEntry) }}
+	{%- for entry in navPages %}{{ renderNavListItem(entry) }}{%- endfor -%}
   </ul>
 </nav>


### PR DESCRIPTION
Adds RSS feed to the main navigation bar as the first item.

I created a manual nav menu item in the nav template, and make use of the same macro as all other nav items. Because the feed is generated using a virtual template, this seemed more straightforward than trying to add it to the eleventyNavigation plugin.

One tradeoff to note here is that this implementation can't utilize the navigation plugin's ordering. The RSS Feed either needs to be first or last in the navigation.