### PR TITLE
fix: add text label to tag list icon instead of separate text

### DIFF
--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -12,8 +12,7 @@ bodyClass: post
 			</a>
 		<h1 class="entry-title">{{ title }}</h1>
 		<span class="tag-links">
-			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M11.3 4.3c-.2-.2-.4-.3-.7-.3H3c-.5 0-1 .5-1 1v6c0 .6.5 1 1 1h7.6c.3 0 .5-.1.7-.3L15 8l-3.7-3.7zM10 9c-.5 0-1-.5-1-1s.5-1 1-1 1 .5 1 1-.5 1-1 1z"/></svg>
-			<span class="screen-reader-text">Tags </span>
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><title>Tag List</title><path d="M11.3 4.3c-.2-.2-.4-.3-.7-.3H3c-.5 0-1 .5-1 1v6c0 .6.5 1 1 1h7.6c.3 0 .5-.1.7-.3L15 8l-3.7-3.7zM10 9c-.5 0-1-.5-1-1s.5-1 1-1 1 .5 1 1-.5 1-1 1z"/></svg>
 			{%- set comma = joiner() %}
 			{%- for tag in tags | filterTagList %}{{ comma() }}
 				<a href="/posts/tags/{{ tag | slugify }}">{{ tag }}</a>


### PR DESCRIPTION
Replaces screen reader text for tag list with an accessible text label for the tag icon. Hopefully prevents screen readers announcing "Blank" after reading the post title.