### PR TITLE
refactor: use actual list element for tags for improved semantics

### DIFF
--- a/_includes/layouts/post.njk
+++ b/_includes/layouts/post.njk
@@ -3,7 +3,7 @@ layout: layouts/base.njk
 bodyClass: post
 ---
 <article class="hentry">
-	<header>
+	<header class="post-header">
 			<a href="{{ page.url }}">
 				<span class="screen-reader-text">
 					Posted on
@@ -11,13 +11,17 @@ bodyClass: post
 				<time datetime="{{ page.date | htmlDateString }}">{{ page.date | readableDate }}</time>
 			</a>
 		<h1 class="entry-title">{{ title }}</h1>
-		<span class="tag-links">
-			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><title>Tag List</title><path d="M11.3 4.3c-.2-.2-.4-.3-.7-.3H3c-.5 0-1 .5-1 1v6c0 .6.5 1 1 1h7.6c.3 0 .5-.1.7-.3L15 8l-3.7-3.7zM10 9c-.5 0-1-.5-1-1s.5-1 1-1 1 .5 1 1-.5 1-1 1z"/></svg>
-			{%- set comma = joiner() %}
-			{%- for tag in tags | filterTagList %}{{ comma() }}
-				<a href="/posts/tags/{{ tag | slugify }}">{{ tag }}</a>
-			{%- endfor %}
-		</span>
+		<div class="tag-links-container">
+			<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" focusable="false" aria-hidden="true"><path d="M11.3 4.3c-.2-.2-.4-.3-.7-.3H3c-.5 0-1 .5-1 1v6c0 .6.5 1 1 1h7.6c.3 0 .5-.1.7-.3L15 8l-3.7-3.7zM10 9c-.5 0-1-.5-1-1s.5-1 1-1 1 .5 1 1-.5 1-1 1z"/></svg>
+			<p class="screen-reader-text" id="tag-list-label">Tags</p>
+			<ul class="tag-links" aria-labelledby="tag-list-label">
+				{%- for tag in tags | filterTagList -%}
+				<li>
+					<a href="/posts/tags/{{ tag | slugify }}">{{ tag }}</a>
+				</li>
+				{%- endfor -%}
+			</ul>
+		</div>
 	</header>
 	<div class="entry-content">
 		{{ content | safe }}

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -1306,6 +1306,12 @@ body > a:first-child:focus {
 	max-width: var(--width);
 }
 
+.post-header {
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}
+
 .entry-footer {
 	margin-bottom: 3rem;
 
@@ -1325,21 +1331,40 @@ body > a:first-child:focus {
 	}
 }
 
+.tag-links-container {
+	display: grid;
+	gap: 0.5rem;
+	grid-template-columns: 16px 1fr;
+	align-items: baseline;
+}
+
+.tag-links-container svg {
+	display: block;
+	fill: currentColor;
+	height: 16px;
+	speak: never;
+	width: 16px;
+}
+
+.tag-links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	list-style-type: none;
+	padding: 0;
+	margin: 0;
+}
+
+.tag-links li:not(:last-child) a::after {
+	content: ",";
+	display: inline-block;
+}
+
 .posted-on,
 .tag-links {
 	font-family: var(--font-mono);
 	font-size: 1.125rem;
 	line-height: 1.6;
-}
-
-.tag-links svg {
-	display: inline-block;
-	fill: currentColor;
-	height: 16px;
-	margin-left: 5px;
-	speak: none;
-	vertical-align: baseline;
-	width: 16px;
 }
 
 /**


### PR DESCRIPTION
Further improve screen reader experience for tags by hiding the icon from screen readers, and using a list element with a text label for the tags themselves. Also lightly adjusts spacing of post header text for an improved sighted reading experience.