### PR TITLE
Minor CSS updates in response to Mastodon accessibility feedback

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -25,11 +25,11 @@ Text Domain: cyanotype
 	--link-hover-color: #d1d1d1;
 
 	/* other variables */
-	--width: 720px;
+	--width: 35em;
 	--font-main: Verdana, "Open Sans", sans-serif;
 	--font-mono: Inconsolata, monospace;
 	--font-cyanotype: Karla, sans-serif;
-	--font-scale: 1.4rem;
+	--font-scale: 1.4em;
 	--background-color: var(--background-colour);
 	--heading-color: var(--foreground-colour);
 	--text-color: var(--foreground-colour);

--- a/public/css/nav.css
+++ b/public/css/nav.css
@@ -309,7 +309,11 @@ a.title:focus {
 	body > nav {
 		display: none;
 	}
-
+	
+	.home-link {
+		margin-left: 2em;
+	}
+	
 	#sidebar-toggle {
 		display: block;
 	}


### PR DESCRIPTION
These CSS changes address the issue raised [in this Mastodon post](https://connectified.com/@masukomi/115695779859767924), specifically adjusting the units used in the main column and the font size for better compatibility with different default font sizes.

In addition, I noticed an issue with the nav menu icon overlapping with the site title in small viewport (mobile) views, and updated one of the nav media queries to resolve this as well.