### PR TITLE
Age Gate Functionality

### DIFF
--- a/_includes/age-gate.njk
+++ b/_includes/age-gate.njk
@@ -1,0 +1,60 @@
+{%- set storage = ageGateStorage if ageGateStorage else 'localStorage' %}
+<div id="age-gate" popover="manual">
+  <h2>Adult Content</h2>
+  <p>This page features adult content. Do you wish to continue?</p>
+  <div>
+    <button
+      id="age-gate-yes-button"
+      popovertarget="age-gate"
+      popovertargetaction="hide"
+      type="button"
+    >
+      Yes
+    </button>
+    <button
+      id="age-gate-no-button"
+      type="button"
+    >
+      No
+    </button>
+  </div>
+</div>
+<style>
+  #age-gate[popover] {
+    border: 2px solid var(--foreground-color);
+    color: var(--foreground-color);
+    background-color: var(--background-color);
+    padding: 2rem;
+
+    div {
+      display: flex;
+      gap: .75rem;
+      justify-content: flex-end;
+    }
+  }
+
+  body:has(.root[aria-hidden]) {
+    border-color: transparent;
+  }
+
+  .root[aria-hidden] {
+    user-select: none;
+    display: none;
+  }
+</style>
+<script type="text/javascript">
+if (window?.{{ storage }}?.getItem('age-gate') !== 'allow' ?? true) {
+  document.getElementById('age-gate')?.showPopover()
+  document.querySelector('{{ ageGatedContent if ageGatedContent else '.root' }}')?.setAttribute('aria-hidden', true)
+
+  document.getElementById('age-gate-yes-button')?.addEventListener('click', () => {
+    window.{{ storage }}?.setItem('age-gate', 'allow')
+    document.querySelector('{{ ageGatedContent if ageGatedContent else '.root' }}')?.removeAttribute('aria-hidden')
+    document.getElementById('age-gate')?.remove()
+  })
+
+  document.getElementById('age-gate-no-button')?.addEventListener('click', () => {
+    window.location = '{{ ageGateSafeUrl if ageGateSafeUrl else '/' }}'
+  })
+}
+</script>

--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -42,25 +42,30 @@
 		{%- js %}{% include "node_modules/@zachleat/heading-anchors/heading-anchors.js" %}{% endjs %}
 	</head>
 	<body>
-		<a href="#skip" class="visually-hidden skip-link">Skip to main content</a>
+		<div class="root">
+			<a href="#skip" class="skip-link">Skip to main content</a>
 
-		{%- include "../navigation.njk" %}
+			{%- include "../navigation.njk" %}
 
-		<header class="site-header">
-			<a href="/" class="home-link">{{ metadata.title }}</a>
-			{%- include "sidebar-button.njk" %}
-		</header>
-		{%- include "sidebar-navigation.njk" %}
+			<header class="site-header">
+				<a href="/" class="home-link">{{ metadata.title }}</a>
+				{%- include "sidebar-button.njk" %}
+			</header>
+			{%- include "sidebar-navigation.njk" %}
 
-		<main id="skip" {{ ' class=' + bodyClass if bodyClass }}>
-			<heading-anchors>
-				{{ content | safe }}
-			</heading-anchors>
-		</main>
-		{%- include "pagination.njk" %}
-		<footer>
-			<p>&copy; {{ metadata.author.name }} {% currentBuildYear %} | <a href="/privacy">Privacy, disclaimers, disclosures.</a></p>
-		</footer>
+			<main id="skip" {{ ' class=' + bodyClass if bodyClass }}>
+				<heading-anchors>
+					{{ content | safe }}
+				</heading-anchors>
+			</main>
+			{%- include "pagination.njk" %}
+			<footer>
+				<p>&copy; {{ metadata.author.name }} {% currentBuildYear %} | <a href="/privacy">Privacy, disclaimers, disclosures.</a></p>
+			</footer>
+		</div>
+    {%- if age_gate %}
+		{% include 'age-gate.njk' %}
+		{%- endif %}
 		<script type="module" src="{% getBundleFileUrl "js" %}"></script>
 	</body>
 </html>


### PR DESCRIPTION
## How It Works

Add the following front matter to any page you want to age gate.

```yaml
age_gate: true
```

When present, pages will be loaded with some JavaScript to popup an HTML native dialog popup box where they are presented with the title "Adult Content" and the explanation "This page features adult content. Do you wish to continue?" with the option of "Yes" and "No".

While this is up the page contents are hidden, and should not be tab-able until an option is selected.

If they choose yes, we set a flag in local storage and will not ask them again unless they clear their browser storage.

If they choose no, we send them to the homepage of the site. If they visit that page again, they are presented with the same yes or no prompt.


## Additional Notes

- We do not want to break readability mode in browsers, RSS readers, or third party read later apps.
- Posts in RSS feed are not age gated.